### PR TITLE
WIP - Add a version of the compatibility suite that runs Servirtium.NET in Docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
 FROM mcr.microsoft.com/dotnet/aspnet:3.1
 COPY Servirtium.StandaloneServer/bin/Release/netcoreapp3.1/ Servirtium/
 WORKDIR /Servirtium
-ENTRYPOINT ["dotnet", "Servirtium.StandaloneServer.dll", "record", "http://todo-backend-sinatra.herokuapp.com", "http://localhost:1234", "--urls=http://*:1234"]
+ENTRYPOINT ["dotnet", "Servirtium.StandaloneServer.dll"]
+CMD ["record", "http://todo-backend-sinatra.herokuapp.com"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,4 @@
+FROM mcr.microsoft.com/dotnet/aspnet:3.1
+COPY Servirtium.StandaloneServer/bin/Release/netcoreapp3.1/ Servirtium/
+WORKDIR /Servirtium
+ENTRYPOINT ["dotnet", "Servirtium.StandaloneServer.dll", "record", "http://todo-backend-sinatra.herokuapp.com", "http://localhost:1234", "--urls=http://*:1234"]

--- a/Servirtium.Core.Tests/Http/FindAndReplaceHttpMessageTransformsTest.cs
+++ b/Servirtium.Core.Tests/Http/FindAndReplaceHttpMessageTransformsTest.cs
@@ -1,0 +1,247 @@
+﻿using Servirtium.Core.Http;
+using System;
+using System.Collections.Generic;
+using System.Net.Http.Headers;
+using System.Text;
+using System.Text.RegularExpressions;
+using Xunit;
+
+namespace Servirtium.Core.Tests.Http
+{
+    public class FindAndReplaceHttpMessageTransformsTest
+    {
+        private static readonly ServiceRequest REQUEST_WITH_TEXT_BODY = new ServiceRequest.Builder()
+            .Body("I want to eat, eat ,eat apples and bananas", MediaTypeHeaderValue.Parse("text/plain"))
+            .Headers(("want","bananas"), ("eat", "apples"))
+            .Build();
+        private static readonly ServiceRequest REQUEST_WITHOUT_BODY = new ServiceRequest.Builder()
+            .Headers(("want", "bananas"), ("eat", "apples"))
+            .Build();
+        private static readonly ServiceRequest REQUEST_WITH_BINARY_BODY = new ServiceRequest.Builder()
+            .Body("I want to eat, eat ,eat apples and bananas", MediaTypeHeaderValue.Parse("application/pdf"))
+            .Headers(("want", "bananas"), ("eat", "apples"))
+            .Build();
+        private static readonly ServiceResponse RESPONSE_WITH_TEXT_BODY = new ServiceResponse.Builder()
+            .Body("I want to eat, eat ,eat apples and bananas", MediaTypeHeaderValue.Parse("text/plain"))
+            .Headers(("want", "bananas"), ("eat", "apples"))
+            .Build();
+        private static readonly ServiceResponse RESPONSE_WITHOUT_BODY = new ServiceResponse.Builder()
+            .Headers(("want", "bananas"), ("eat", "apples"))
+            .Build();
+        private static readonly ServiceResponse RESPONSE_WITH_BINARY_BODY = new ServiceResponse.Builder()
+            .Body("I want to eat, eat ,eat apples and bananas", MediaTypeHeaderValue.Parse("application/pdf"))
+            .Headers(("want", "bananas"), ("eat", "apples"))
+            .Build();
+
+        [Fact]
+        public void TransformClientRequestForRealService_NoReplacements_ReturnsSameRequest()
+        {
+            var transformed = new FindAndReplaceHttpMessageTransforms(new RegexReplacement[0]).TransformClientRequestForRealService(REQUEST_WITH_TEXT_BODY);
+            Assert.Equal(REQUEST_WITH_TEXT_BODY, transformed);
+        }
+
+        [Fact]
+        public void TransformClientRequestForRealService_OnlyResponseReplacements_ReturnsSameRequest()
+        {
+            var transformed = new FindAndReplaceHttpMessageTransforms(
+                new RegexReplacement[] { 
+                    new RegexReplacement(new Regex("bananas"), "bununus", ReplacementContext.ResponseBody),
+                    new RegexReplacement(new Regex("apples"), "upples", ReplacementContext.ResponseHeader)
+                }).TransformClientRequestForRealService(REQUEST_WITH_TEXT_BODY);
+            Assert.Equal(REQUEST_WITH_TEXT_BODY, transformed);
+        }
+
+        [Fact]
+        public void TransformClientRequestForRealService_ScopedRequestReplacements_OnlyReplacesInScope()
+        {
+            var transformed = new FindAndReplaceHttpMessageTransforms(
+                new RegexReplacement[] {
+                    new RegexReplacement(new Regex("bananas"), "bununus", ReplacementContext.RequestBody),
+                    new RegexReplacement(new Regex("apples"), "upples", ReplacementContext.RequestHeader)
+                }).TransformClientRequestForRealService(REQUEST_WITH_TEXT_BODY);
+            Assert.Equal(
+                new ServiceRequest.Builder()
+                    .From(REQUEST_WITH_TEXT_BODY)
+                    .Headers(("want", "bananas"), ("eat", "upples"))
+                    .Body("I want to eat, eat ,eat apples and bununus", MediaTypeHeaderValue.Parse("text/plain"))
+                    .Build(),
+                transformed
+            );
+        }
+
+        [Fact]
+        public void TransformClientRequestForRealService_MultiScopedRequestReplacements_ReplacesInHeaderAndBody()
+        {
+            var transformed = new FindAndReplaceHttpMessageTransforms(
+                new RegexReplacement[] {
+                    new RegexReplacement(new Regex("bananas"), "bununus", ReplacementContext.RequestBody | ReplacementContext.RequestHeader),
+                    new RegexReplacement(new Regex("apples"), "upples", ReplacementContext.RequestHeader)
+                }).TransformClientRequestForRealService(REQUEST_WITH_TEXT_BODY);
+            Assert.Equal(
+                new ServiceRequest.Builder()
+                    .From(REQUEST_WITH_TEXT_BODY)
+                    .Headers(("want", "bununus"), ("eat", "upples"))
+                    .Body("I want to eat, eat ,eat apples and bununus", MediaTypeHeaderValue.Parse("text/plain"))
+                    .Build(),
+                transformed
+            );
+        }
+
+        [Fact]
+        public void TransformClientRequestForRealService_MultipleRequestReplacements_ReplacesInOrderSpecified()
+        {
+            var transformed = new FindAndReplaceHttpMessageTransforms(
+                new RegexReplacement[] {
+                    new RegexReplacement(new Regex("b[a-z]n[a-z]n[a-z]s"), "bununus", ReplacementContext.RequestHeader),
+                    new RegexReplacement(new Regex("b[a-z]n[a-z]n[a-z]s"), "bononos", ReplacementContext.RequestHeader)
+                }).TransformClientRequestForRealService(REQUEST_WITH_TEXT_BODY);
+            Assert.Equal(
+                new ServiceRequest.Builder()
+                    .From(REQUEST_WITH_TEXT_BODY)
+                    .Headers(("want", "bononos"), ("eat", "apples"))
+                    .Build(),
+                transformed
+            );
+        }
+
+        [Fact]
+        public void TransformClientRequestForRealService_RequestHasNoBody_IgnoresRequestBodyReplacements()
+        {
+            var transformed = new FindAndReplaceHttpMessageTransforms(
+                new RegexReplacement[] {
+                    new RegexReplacement(new Regex("bananas"), "bununus", ReplacementContext.RequestBody | ReplacementContext.RequestHeader),
+                    new RegexReplacement(new Regex("apples"), "upples", ReplacementContext.RequestHeader)
+                }).TransformClientRequestForRealService(REQUEST_WITHOUT_BODY);
+            Assert.Equal(
+                new ServiceRequest.Builder()
+                    .From(REQUEST_WITHOUT_BODY)
+                    .Headers(("want", "bununus"), ("eat", "upples"))
+                    .Build(),
+                transformed
+            );
+        }
+
+        [Fact]
+        public void TransformClientRequestForRealService_RequestHasBinaryBody_IgnoresRequestBodyReplacements()
+        {
+            var transformed = new FindAndReplaceHttpMessageTransforms(
+                new RegexReplacement[] {
+                    new RegexReplacement(new Regex("bananas"), "bununus", ReplacementContext.RequestBody | ReplacementContext.RequestHeader),
+                    new RegexReplacement(new Regex("apples"), "upples", ReplacementContext.RequestHeader)
+                }).TransformClientRequestForRealService(REQUEST_WITH_BINARY_BODY);
+            Assert.Equal(
+                new ServiceRequest.Builder()
+                    .From(REQUEST_WITH_BINARY_BODY)
+                    .Headers(("want", "bununus"), ("eat", "upples"))
+                    .Build(),
+                transformed
+            );
+        }
+
+
+        [Fact]
+        public void TransformRealServiceResponseForClient_NoReplacements_ReturnsSameResponse()
+        {
+            var transformed = new FindAndReplaceHttpMessageTransforms(new RegexReplacement[0]).TransformRealServiceResponseForClient(RESPONSE_WITH_TEXT_BODY);
+            Assert.Equal(RESPONSE_WITH_TEXT_BODY, transformed);
+        }
+
+        [Fact]
+        public void TransformRealServiceResponseForClient_OnlyRequestReplacements_ReturnsSameResponse()
+        {
+            var transformed = new FindAndReplaceHttpMessageTransforms(
+                new RegexReplacement[] {
+                    new RegexReplacement(new Regex("bananas"), "bununus", ReplacementContext.RequestBody),
+                    new RegexReplacement(new Regex("apples"), "upples", ReplacementContext.RequestHeader)
+                }).TransformRealServiceResponseForClient(RESPONSE_WITH_TEXT_BODY);
+            Assert.Equal(RESPONSE_WITH_TEXT_BODY, transformed);
+        }
+
+        [Fact]
+        public void TransformRealServiceResponseForClient_ScopedResponseReplacements_OnlyReplacesInScope()
+        {
+            var transformed = new FindAndReplaceHttpMessageTransforms(
+                new RegexReplacement[] {
+                    new RegexReplacement(new Regex("bananas"), "bununus", ReplacementContext.ResponseBody),
+                    new RegexReplacement(new Regex("apples"), "upples", ReplacementContext.ResponseHeader)
+                }).TransformRealServiceResponseForClient(RESPONSE_WITH_TEXT_BODY);
+            Assert.Equal(
+                new ServiceResponse.Builder()
+                    .From(RESPONSE_WITH_TEXT_BODY)
+                    .Headers(("want", "bananas"), ("eat", "upples"))
+                    .Body("I want to eat, eat ,eat apples and bununus", MediaTypeHeaderValue.Parse("text/plain"))
+                    .Build(),
+                transformed
+            );
+        }
+
+        [Fact]
+        public void TransformRealServiceResponseForClient_MultiScopedRequestReplacements_ReplacesInHeaderAndBody()
+        {
+            var transformed = new FindAndReplaceHttpMessageTransforms(
+                new RegexReplacement[] {
+                    new RegexReplacement(new Regex("bananas"), "bununus", ReplacementContext.ResponseBody | ReplacementContext.ResponseHeader),
+                    new RegexReplacement(new Regex("apples"), "upples", ReplacementContext.ResponseHeader)
+                }).TransformRealServiceResponseForClient(RESPONSE_WITH_TEXT_BODY);
+            Assert.Equal(
+                new ServiceResponse.Builder()
+                    .From(RESPONSE_WITH_TEXT_BODY)
+                    .Headers(("want", "bununus"), ("eat", "upples"))
+                    .Body("I want to eat, eat ,eat apples and bununus", MediaTypeHeaderValue.Parse("text/plain"))
+                    .Build(),
+                transformed
+            );
+        }
+
+        [Fact]
+        public void TransformRealServiceResponseForClient_MultipleResponseReplacements_ReplacesInOrderSpecified()
+        {
+            var transformed = new FindAndReplaceHttpMessageTransforms(
+                new RegexReplacement[] {
+                    new RegexReplacement(new Regex("b[a-z]n[a-z]n[a-z]s"), "bununus", ReplacementContext.ResponseHeader),
+                    new RegexReplacement(new Regex("b[a-z]n[a-z]n[a-z]s"), "bononos", ReplacementContext.ResponseHeader)
+                }).TransformRealServiceResponseForClient(RESPONSE_WITH_TEXT_BODY);
+            Assert.Equal(
+                new ServiceResponse.Builder()
+                    .From(RESPONSE_WITH_TEXT_BODY)
+                    .Headers(("want", "bononos"), ("eat", "apples"))
+                    .Build(),
+                transformed
+            );
+        }
+
+        [Fact]
+        public void TransformRealServiceResponseForClient_ResponseHasNoBody_IgnoresResponseBodyReplacements()
+        {
+            var transformed = new FindAndReplaceHttpMessageTransforms(
+                new RegexReplacement[] {
+                    new RegexReplacement(new Regex("bananas"), "bununus", ReplacementContext.ResponseBody | ReplacementContext.ResponseHeader),
+                    new RegexReplacement(new Regex("apples"), "upples", ReplacementContext.ResponseHeader)
+                }).TransformRealServiceResponseForClient(RESPONSE_WITHOUT_BODY);
+            Assert.Equal(
+                new ServiceResponse.Builder()
+                    .From(RESPONSE_WITHOUT_BODY)
+                    .Headers(("want", "bununus"), ("eat", "upples"))
+                    .Build(),
+                transformed
+            );
+        }
+
+        [Fact]
+        public void TransformRealServiceResponseForClient_ResponseHasBinaryBody_IgnoresRequestBodyReplacements()
+        {
+            var transformed = new FindAndReplaceHttpMessageTransforms(
+                new RegexReplacement[] {
+                    new RegexReplacement(new Regex("bananas"), "bununus", ReplacementContext.ResponseBody | ReplacementContext.ResponseHeader),
+                    new RegexReplacement(new Regex("apples"), "upples", ReplacementContext.ResponseHeader)
+                }).TransformRealServiceResponseForClient(RESPONSE_WITH_BINARY_BODY);
+            Assert.Equal(
+                new ServiceResponse.Builder()
+                    .From(RESPONSE_WITH_BINARY_BODY)
+                    .Headers(("want", "bununus"), ("eat", "upples"))
+                    .Build(),
+                transformed
+            );
+        }
+    }
+}

--- a/Servirtium.Core.Tests/Http/HttpMessageTransformPipelineTest.cs
+++ b/Servirtium.Core.Tests/Http/HttpMessageTransformPipelineTest.cs
@@ -1,0 +1,90 @@
+﻿using Servirtium.Core.Http;
+using System.Net.Http.Headers;
+using System.Text;
+using Xunit;
+
+namespace Servirtium.Core.Http.Tests
+{
+    public class TestHttpMessageTransform : IHttpMessageTransforms
+    {
+        private readonly string _append; 
+
+        public TestHttpMessageTransform(string append) 
+        {
+            _append = append;
+        }
+
+        public IRequestMessage TransformClientRequestForRealService(IRequestMessage clientRequest) => new ServiceRequest.Builder()
+            .From(clientRequest)
+            .Body($"{Encoding.UTF8.GetString(clientRequest.Body.Value.Content)}-{_append}", clientRequest.Body.Value.Type)
+            .Build();
+
+        public IResponseMessage TransformRealServiceResponseForClient(IResponseMessage serviceResponse) => new ServiceResponse.Builder()
+            .From(serviceResponse)
+            .Body($"{Encoding.UTF8.GetString(serviceResponse.Body.Value.Content)}-{_append}", serviceResponse.Body.Value.Type)
+            .Build();
+    }
+
+    public class HttpMessageTransformPipelineTest
+    {
+        private static readonly ServiceRequest REQUEST = new ServiceRequest.Builder()
+            .Body("BODY", MediaTypeHeaderValue.Parse("text/plain"))
+            .Build();
+
+        private static readonly ServiceResponse RESPONSE = new ServiceResponse.Builder()
+            .Body("BODY", MediaTypeHeaderValue.Parse("text/plain"))
+            .Build();
+
+        [Fact]
+        public void TransformClientRequestForRealService_NoTransforms_ReturnsUnmodifiedRequest()
+        {
+            Assert.Equal(REQUEST, new HttpMessageTransformPipeline().TransformClientRequestForRealService(REQUEST));
+        }
+
+        [Fact]
+        public void TransformClientRequestForRealService_OneTransform_DelegatesToTransform()
+        {
+            Assert.Equal(
+                new ServiceRequest.Builder().From(REQUEST).Body("BODY-A", MediaTypeHeaderValue.Parse("text/plain")).Build(), 
+                new HttpMessageTransformPipeline(new TestHttpMessageTransform("A")).TransformClientRequestForRealService(REQUEST)
+            );
+        }
+
+        [Fact]
+        public void TransformClientRequestForRealService_MultipleTransform_AppliesTransformsInParameterOrder()
+        {
+            Assert.Equal(
+                new ServiceRequest.Builder().From(REQUEST).Body("BODY-A-B-C", MediaTypeHeaderValue.Parse("text/plain")).Build(),
+                new HttpMessageTransformPipeline(
+                    new TestHttpMessageTransform("A"), new TestHttpMessageTransform("B"), new TestHttpMessageTransform("C"))
+                        .TransformClientRequestForRealService(REQUEST)
+            );
+        }
+
+        [Fact]
+        public void TransformRealServiceResponseForClient_NoTransforms_ReturnsUnmodifiedRequest()
+        {
+            Assert.Equal(RESPONSE, new HttpMessageTransformPipeline().TransformRealServiceResponseForClient(RESPONSE));
+        }
+
+        [Fact]
+        public void TransformRealServiceResponseForClient_OneTransform_DelegatesToTransform()
+        {
+            Assert.Equal(
+                new ServiceResponse.Builder().From(RESPONSE).Body("BODY-A", MediaTypeHeaderValue.Parse("text/plain")).Build(),
+                new HttpMessageTransformPipeline(new TestHttpMessageTransform("A")).TransformRealServiceResponseForClient(RESPONSE)
+            );
+        }
+
+        [Fact]
+        public void TransformRealServiceResponseForClient_MultipleTransform_AppliesTransformsInParameterOrder()
+        {
+            Assert.Equal(
+                new ServiceResponse.Builder().From(RESPONSE).Body("BODY-A-B-C", MediaTypeHeaderValue.Parse("text/plain")).Build(),
+                new HttpMessageTransformPipeline(
+                    new TestHttpMessageTransform("A"), new TestHttpMessageTransform("B"), new TestHttpMessageTransform("C"))
+                        .TransformRealServiceResponseForClient(RESPONSE)
+            );
+        }
+    }
+}

--- a/Servirtium.Core.Tests/Interactions/MarkdownScriptWriterTest.cs
+++ b/Servirtium.Core.Tests/Interactions/MarkdownScriptWriterTest.cs
@@ -221,7 +221,7 @@ namespace Servirtium.Core.Tests.Interactions
                 .Build();
 
             var interactionText = new StringBuilder();
-            Assert.Throws<ArgumentException>(()=>new MarkdownScriptWriter().Write(new StringWriter(interactionText), interactions));
+            Assert.Throws<MissingInteractionException>(()=>new MarkdownScriptWriter().Write(new StringWriter(interactionText), interactions));
         }
 
 

--- a/Servirtium.Core/Interactions/InteractionRecorder.cs
+++ b/Servirtium.Core/Interactions/InteractionRecorder.cs
@@ -6,39 +6,91 @@ using System.Text;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
+using System.Linq;
+using System.Collections.Concurrent;
 
 namespace Servirtium.Core.Interactions
 {
     public class InteractionRecorder : IInteractionMonitor
     {
+        private enum InteractionState
+        {
+            Pending, Recorded
+        }
+
+        public enum RecordTime
+        {
+            AfterEachInteraction,
+            AfterScriptFinishes
+        }
+
         private readonly ILogger<InteractionRecorder> _logger;
         private readonly IServiceInteroperation _service;
         private readonly IScriptWriter _scriptWriter;
         private readonly Uri? _redirectHost;
-        private readonly IDictionary<int, IInteraction> _allInteractions;
+        private readonly ConcurrentDictionary<int, (IInteraction interaction, InteractionState state)> _allInteractions;
         private readonly Func<TextWriter> _writerFactory;
 
         private readonly IBodyFormatter _requestBodyFormatter;
         private readonly IBodyFormatter _responseBodyFormatter;
+
+        private readonly RecordTime _recordTime;
         
-        public InteractionRecorder(string targetFile, IScriptWriter scriptWriter, bool bypassProxy = false, ILoggerFactory? loggerFactory = null) : this(null, () => File.CreateText(targetFile), scriptWriter, new ServiceInteropViaSystemNetHttp(bypassProxy, loggerFactory)) { }
+        public InteractionRecorder(string targetFile, IScriptWriter scriptWriter, bool bypassProxy = false, ILoggerFactory? loggerFactory = null, RecordTime recordTime = RecordTime.AfterScriptFinishes)
+            : this(null, () => File.AppendText(targetFile), scriptWriter, new ServiceInteropViaSystemNetHttp(bypassProxy, loggerFactory), null, null, null, null, recordTime) { }
 
-        public InteractionRecorder(Uri redirectHost, string targetFile, IScriptWriter scriptWriter, ILoggerFactory? loggerFactory = null) : this(redirectHost, targetFile, scriptWriter, new ServiceInteropViaSystemNetHttp(false, loggerFactory)) { }
+        public InteractionRecorder(Uri redirectHost, string targetFile, IScriptWriter scriptWriter, ILoggerFactory? loggerFactory = null, RecordTime recordTime = RecordTime.AfterScriptFinishes) 
+            : this(redirectHost, () => File.AppendText(targetFile), scriptWriter, new ServiceInteropViaSystemNetHttp(false, loggerFactory), null, null, null, null, recordTime) { }
 
-        public InteractionRecorder(Uri redirectHost, string targetFile, IScriptWriter scriptWriter, IServiceInteroperation service, IDictionary<int, IInteraction>? interactions = null, ILoggerFactory? loggerFactory = null)
-            : this(redirectHost, () => File.CreateText(targetFile), scriptWriter, service, interactions, null, null, loggerFactory)
-        { }
+        public InteractionRecorder(Uri redirectHost, string targetFile, IScriptWriter scriptWriter, IServiceInteroperation service, IDictionary<int, IInteraction>? interactions = null, ILoggerFactory? loggerFactory = null, RecordTime recordTime = RecordTime.AfterScriptFinishes)
+            : this(redirectHost, () => File.AppendText(targetFile), scriptWriter, service, interactions, null, null, loggerFactory, recordTime)
+        {
+            //Ensure file is blank first
+            using (File.CreateText(targetFile)) ;
+        }
 
-        public InteractionRecorder(Uri? redirectHost, Func<TextWriter> outputWriterFactory, IScriptWriter scriptWriter, IServiceInteroperation service, IDictionary<int, IInteraction>? interactions = null, IBodyFormatter? responseBodyFormatter = null, IBodyFormatter? requestBodyFormatter = null, ILoggerFactory? loggerFactory = null)
+        public InteractionRecorder(Uri? redirectHost, Func<TextWriter> outputWriterFactory, IScriptWriter scriptWriter, IServiceInteroperation service, IDictionary<int, IInteraction>? interactions = null, IBodyFormatter? responseBodyFormatter = null, IBodyFormatter? requestBodyFormatter = null, ILoggerFactory? loggerFactory = null, RecordTime recordTime = RecordTime.AfterScriptFinishes)
         {
             _logger = (loggerFactory ?? NullLoggerFactory.Instance).CreateLogger<InteractionRecorder>();
             _redirectHost = redirectHost;
             _service = service;
             _scriptWriter = scriptWriter;
-            _allInteractions = interactions ?? new Dictionary<int, IInteraction> { };
+            _allInteractions = new ConcurrentDictionary<int, (IInteraction interaction, InteractionState state)>((interactions ?? new Dictionary<int, IInteraction> { }).ToDictionary(kvp=>kvp.Key, kvp=>(kvp.Value, InteractionState.Pending)));
             _writerFactory = outputWriterFactory;
             _requestBodyFormatter = requestBodyFormatter ?? new TextAndBinaryBodyFormatter(new UTF8TextBodyFormatter(), new Base64BinaryBodyFormatter(), loggerFactory);
             _responseBodyFormatter = responseBodyFormatter ?? new TextAndBinaryBodyFormatter(new UTF8TextBodyFormatter(), new Base64BinaryBodyFormatter(), loggerFactory);
+            _recordTime = recordTime;
+        }
+
+        private void RecordPendingInteractions() 
+        {
+            lock (_logger)
+            {
+                var pending = _allInteractions.Where(kvp => kvp.Value.state == InteractionState.Pending)
+                    .ToDictionary(kvp => kvp.Key, kvp => kvp.Value.interaction);
+                using (var fs = _writerFactory())
+                {
+
+                    try
+                    {
+                        _scriptWriter.Write(
+                            fs,
+                            pending);
+                    }
+                    catch (MissingInteractionException ex)
+                    {
+                        foreach (var kvp in pending.Where(kvp => kvp.Value.Number < ex.MissingInteractionNumber)) 
+                        {
+                            _allInteractions[kvp.Key] = (kvp.Value, InteractionState.Recorded);    
+                        }
+                        throw;
+                    }
+                    foreach(var kvp in pending)
+                    {
+                        _allInteractions[kvp.Key] = (kvp.Value, InteractionState.Recorded);
+                    }
+                }
+            }
         }
 
         public async Task<IResponseMessage> GetServiceResponseForRequest(int interactionNumber, IRequestMessage request, bool lowerCaseHeaders = false)
@@ -82,18 +134,36 @@ namespace Servirtium.Core.Interactions
                 builder.RemoveResponseBody();
             }
             var interactionToRecord = builder.Build();
+
             _logger.LogDebug($"Noting interaction {interactionToRecord.Number}.");
-            _allInteractions.Add(interactionToRecord.Number, interactionToRecord);
+            if (!_allInteractions.TryAdd(interactionToRecord.Number,(interactionToRecord, InteractionState.Pending)))
+            {
+                throw new ArgumentException($"Duplicate interaction number: {interactionToRecord.Number}, request: {interactionToRecord.Method} {interactionToRecord.Path}");
+            }
+
+            if (_recordTime == RecordTime.AfterEachInteraction)
+            {
+                _logger.LogDebug($"Recording pending interactions up to {interactionToRecord.Number}.");
+                try
+                {
+                    RecordPendingInteractions();
+                }
+                catch (MissingInteractionException ex)
+                {
+                    _logger.LogInformation($"Interaction No. {ex.MissingInteractionNumber} is not available, stopping recording here.");
+                }
+
+            }
         }
 
         public void FinishedScript(int interactionNum, bool failed)
         {
-            _logger.LogDebug($"Finishing script, writing {_allInteractions.Count} interactions.");
-            using (var fs = _writerFactory())
+            if (_recordTime == RecordTime.AfterScriptFinishes)
             {
-                _scriptWriter.Write(fs, _allInteractions);
+                _logger.LogDebug($"Finishing script, writing {_allInteractions.Count} interactions.");
+                RecordPendingInteractions();
+                _logger.LogInformation($"Finished script, wrote {_allInteractions.Count} interactions.");
             }
-            _logger.LogInformation($"Finished script, wrote {_allInteractions.Count} interactions.");
         }
     }
 }

--- a/Servirtium.Core/Interactions/MissingInteractionException.cs
+++ b/Servirtium.Core/Interactions/MissingInteractionException.cs
@@ -1,0 +1,16 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Servirtium.Core.Interactions
+{
+    public class MissingInteractionException : Exception
+    {
+        public MissingInteractionException(string message, int interactionNumber) : base(message)
+        {
+            MissingInteractionNumber = interactionNumber;
+        }
+
+        public int MissingInteractionNumber { get; }
+    }
+}

--- a/Servirtium.StandaloneServer/Program.cs
+++ b/Servirtium.StandaloneServer/Program.cs
@@ -43,9 +43,11 @@ namespace Servirtium.StandaloneServer
                     {
                         monitor = new InteractionRecorder(
                             Path.Combine(RECORDING_OUTPUT_DIRECTORY, $"recording_{DateTime.UtcNow:yyyy-MM-dd-HHmmss}.md"),
-                            new MarkdownScriptWriter(), 
+                            new MarkdownScriptWriter(null, loggerFactory), 
                             false,
-                            loggerFactory
+                            loggerFactory,
+                            //Write each interaction after it completes rather than all at the end, so it isn't disrupted by unceremonious teardowns (like via a docker container stopping).
+                            InteractionRecorder.RecordTime.AfterEachInteraction
                         );
                         break;
                     }
@@ -59,12 +61,13 @@ namespace Servirtium.StandaloneServer
                     new SimpleHttpMessageTransforms(
                         new Uri(sourceUrl),
                         new Regex[] { },
-                        new[] { new Regex("Date:") }
+                        new[] { new Regex("Date:") },
+                        loggerFactory
                     ),
                     new FindAndReplaceHttpMessageTransforms(
                         new[] {
                             new RegexReplacement(new Regex(Regex.Escape(sourceUrl)), args[2], ReplacementContext.ResponseBody)
-                        })
+                        }, loggerFactory)
                 ),
                 loggerFactory
             );

--- a/Servirtium.StandaloneServer/Program.cs
+++ b/Servirtium.StandaloneServer/Program.cs
@@ -26,6 +26,7 @@ namespace Servirtium.StandaloneServer
                     .AddFilter(level => true)
                     .AddConsole();
             });
+            var logger = loggerFactory.CreateLogger<Program>();
             IInteractionMonitor monitor;
             switch (command)
             {
@@ -71,10 +72,15 @@ namespace Servirtium.StandaloneServer
                 ),
                 loggerFactory
             );
+            logger.LogInformation("Starting up Servirtium Standalone Server.");
             server.Start().Wait();
-            AppDomain.CurrentDomain.ProcessExit += (a, e) => server.Stop().Wait();
-            Console.Read();
-
+            AppDomain.CurrentDomain.ProcessExit += (a, e) =>
+            {
+                logger.LogInformation("Servirtium Standalone Server attempted graceful shutdown.");
+                server.Stop().Wait();
+            };
+            while (Console.ReadLine()?.ToLower() != "exit") { }
+            logger.LogDebug("Servirtium Standalone Server received 'exit' command, shutting down.");
             server.Stop().Wait();
         }
 

--- a/Servirtium.StandaloneServer/Program.cs
+++ b/Servirtium.StandaloneServer/Program.cs
@@ -17,6 +17,7 @@ namespace Servirtium.StandaloneServer
 
         public static void Main(string[] args)
         {
+            var port = args.Length > 2 ? ushort.Parse(args[2]) : (ushort)1234;
             var command = args[0].ToLower();
             var sourceUrl = args[1];
             var scriptDirectory = Directory.CreateDirectory(RECORDING_OUTPUT_DIRECTORY);
@@ -56,7 +57,7 @@ namespace Servirtium.StandaloneServer
                     throw new ArgumentException($"Unsupported command: '{command}', supported commands are 'playback' and 'record'.");
             };
             var server = AspNetCoreServirtiumServer.WithCommandLineArgs(
-                args, 
+                args.Append($"--urls=http://*:{port}").ToArray(), 
                 monitor, 
                 new HttpMessageTransformPipeline(
                     new SimpleHttpMessageTransforms(
@@ -67,7 +68,7 @@ namespace Servirtium.StandaloneServer
                     ),
                     new FindAndReplaceHttpMessageTransforms(
                         new[] {
-                            new RegexReplacement(new Regex(Regex.Escape(sourceUrl)), args[2], ReplacementContext.ResponseBody)
+                            new RegexReplacement(new Regex(Regex.Escape(sourceUrl)), $"http://localhost:{port}", ReplacementContext.ResponseBody)
                         }, loggerFactory)
                 ),
                 loggerFactory

--- a/Servirtium.StandaloneServer/Properties/launchSettings.json
+++ b/Servirtium.StandaloneServer/Properties/launchSettings.json
@@ -11,7 +11,7 @@
   "profiles": {
     "Record": {
       "commandName": "Project",
-      "commandLineArgs": "record http://todo-backend-sinatra.herokuapp.com http://localhost:1234 --urls=http://*:1234"
+      "commandLineArgs": "record http://todo-backend-sinatra.herokuapp.com 61417"
     },
     "Playback": {
       "commandName": "Project",

--- a/Servirtium.StandaloneServer/Servirtium.StandaloneServer.csproj
+++ b/Servirtium.StandaloneServer/Servirtium.StandaloneServer.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>netcoreapp3.1</TargetFramework>
     <PackageId>Servirtium.StandaloneServer</PackageId>
     <VersionPrefix>1.1.0</VersionPrefix>
-    <VersionSuffix>dev.1</VersionSuffix>
+    <VersionSuffix>dev.3</VersionSuffix>
     <PackageProjectUrl>https://github.com/servirtium/servirtium-dotnet</PackageProjectUrl>
     <Nullable>enable</Nullable>
     <Authors>Stephen Hand</Authors>

--- a/Servirtium.sln
+++ b/Servirtium.sln
@@ -11,7 +11,9 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Servirtium.Core.Tests", "Se
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{70C121B4-5E08-46A6-ACE2-7B2C63D78333}"
 	ProjectSection(SolutionItems) = preProject
+		compatibility-suite-docker.py = compatibility-suite-docker.py
 		compatibility-suite.py = compatibility-suite.py
+		Dockerfile = Dockerfile
 		README.md = README.md
 	EndProjectSection
 EndProject

--- a/Servirtium.sln
+++ b/Servirtium.sln
@@ -21,6 +21,11 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Servirtium.StandaloneServer
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Servirtium.AspNetCore.Tests", "Servirtium.AspNetCore.Tests\Servirtium.AspNetCore.Tests.csproj", "{7C2DCE46-2A2D-4149-B3CF-7FE31260BE94}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Docker", "Docker", "{AC5600F5-24EA-4963-B1FE-8BAE31704408}"
+	ProjectSection(SolutionItems) = preProject
+		entrypoint.sh = entrypoint.sh
+	EndProjectSection
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -50,6 +55,9 @@ Global
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(NestedProjects) = preSolution
+		{AC5600F5-24EA-4963-B1FE-8BAE31704408} = {70C121B4-5E08-46A6-ACE2-7B2C63D78333}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {99E46C9B-C952-4A24-B3CB-DE1B9091BE26}

--- a/compatibility-suite-docker.py
+++ b/compatibility-suite-docker.py
@@ -29,10 +29,10 @@ docker_args = ["docker", "run", "-p", "%s:%s" %(str(args.port), str(args.port)),
 
 if args.mode == "record":
     # TODO check that .NET process is already started.
-    subprocess.Popen(docker_args + ["servirtium-dotnet-standalone-server", "record", args.backend, str(args.port)])
+    subprocess.call(docker_args + ["servirtium-dotnet-standalone-server", "record", args.backend, str(args.port)])
     print("Docker record container: servirtium-compatibility-test")
 elif args.mode == "playback":
-    subprocess.Popen(docker_args + [ "servirtium-dotnet-standalone-server", "playback", args.backend, str(args.port)])
+    subprocess.call(docker_args + [ "servirtium-dotnet-standalone-server", "playback", args.backend, str(args.port)])
     print("Docker playback container: servirtium-compatibility-test")
 elif args.mode == "direct":
     print("showing reference Sinatra app online without Servirtium in the middle")

--- a/compatibility-suite-docker.py
+++ b/compatibility-suite-docker.py
@@ -68,7 +68,7 @@ print("mode: " + args.mode)
 
 
 print("Killing Servirtium.NET")
-subprocess.Popen(["docker", "stop", "servirtium-compatibility-test"])
+subprocess.call(["docker", "stop", "servirtium-compatibility-test"])
 
 print("Closing Selenium")
 chrome.quit()

--- a/compatibility-suite-docker.py
+++ b/compatibility-suite-docker.py
@@ -10,8 +10,6 @@ from selenium.webdriver.support import expected_conditions as EC
 import subprocess
 import time
 import argparse
-import os.path
-from os import path
 
 parser = argparse.ArgumentParser(description='Run Servirtium.NET.')
 parser.add_argument("mode", help="Servirtium's mode of operation, i.e. recording a new script or playing an existing one back", choices = ["record", "playback", "direct"])
@@ -20,41 +18,28 @@ parser.add_argument("-d", "--chromedriver", help="The location of the Selenium C
 parser.add_argument("-t", "--testpage", help="The page to point chrome at to run the tests, use the '%%s' token where the port should be specified. To point back at the original todobackend, specify http://www.todobackend.com/specs/index.html?http://localhost:%%s/todos", default="https://servirtium.github.io/compatibility-suite/#port=%s")
 parser.add_argument("--backend", help="The real todo backend implementation, only used in 'record' or 'direct' mode", default="http://todo-backend-sinatra.herokuapp.com")
 parser.add_argument("--timeoutseconds", help="Number of seconds to wait before giving up on a successful run and ending the test run", type=int, default=20)
-parser.add_argument("--serverversion", help="Version of Standalone.Server to use - this is the version it will pull from Nuget. Setting this will make the script to try to get the Servirtium.StandaloneServer from nuget, rather than building from source.")
-parser.add_argument("--nuget", help="Nuget.exe executable path. Default is to use one on the system PATH", default="nuget")
 
 args = parser.parse_args()
 
-dotnet_platform = "netcoreapp3.1"
-
-dotnet_process = None
-# os.environ["HTTP_PROXY"] = "http://localhost:%s" %(args.port)
 browser_url = args.testpage %(args.port)
 
-if args.mode == "direct":
+subprocess.call(["docker", "volume", "create", "scripts"])
+
+docker_args = ["docker", "run", "-p", "%s:%s" %(str(args.port), str(args.port)), "--volume", "scripts:/Servirtium/test_recording_output", "--name", "servirtium-compatibility-test", "--rm", "-d"]
+
+if args.mode == "record":
+    # TODO check that .NET process is already started.
+    subprocess.Popen(docker_args + ["servirtium-dotnet-standalone-server", "record", args.backend, str(args.port)])
+    print("Docker record container: servirtium-compatibility-test")
+elif args.mode == "playback":
+    subprocess.Popen(docker_args + [ "servirtium-dotnet-standalone-server", "playback", args.backend, str(args.port)])
+    print("Docker playback container: servirtium-compatibility-test")
+elif args.mode == "direct":
+    print("showing reference Sinatra app online without Servirtium in the middle")
     browser_url = "http://www.todobackend.com/specs/index.html?%s" %(args.backend)
 else:
-    servirtium_args = []
-    servirtium_launch_command = []
-
-    if args.mode == "record":
-        servirtium_args = ["record", args.backend, "http://localhost:%s" %(args.port), "--urls=http://*:%s" %(args.port)]
-    elif args.mode == "playback":
-        servirtium_args = ["playback", args.backend, "--urls=http://*:%s" %(args.port)]
-    if args.serverversion:
-        #Install from Nuget
-        subprocess.call([args.nuget, "install", "Servirtium.StandaloneServer", "-OutputDirectory", "executable-packages", "-PreRelease", "-NonInteractive", "-Version", args.serverversion])
-        serverpath = "executable-packages/Servirtium.StandaloneServer.%s/lib/%s/Servirtium.StandaloneServer.exe" %(args.serverversion, dotnet_platform)
-        servirtium_launch_command = [serverpath]
-    else:
-        #Build the Servirtium server first if required
-        subprocess.call(["dotnet", "build", "./Servirtium.StandaloneServer/Servirtium.StandaloneServer.csproj"])
-        servirtium_launch_command = ["dotnet", "run", "--project", "./Servirtium.StandaloneServer/Servirtium.StandaloneServer.csproj", "--no-build", "--"]
-    
-    # TODO check that .NET process is already started.
-    with open('compatibility_suite_servirtium_server.log', "w") as outfile:
-        dotnet_process = subprocess.Popen(servirtium_launch_command + servirtium_args, stdout = outfile, stdin = subprocess.PIPE)
-    print("Servirtium.NET server %s (from %s) started - process id: %s " %(args.mode, str(dotnet_process.pid), "Nuget - version "+args.serverversion if args.serverversion else "source"))
+    print("Second arg should be record or playback")
+    exit(10)
 
 chrome_options = webdriver.ChromeOptions()
 #chrome_options.add_argument("--proxy-server=%s" % "localhost:%s" %(args.port))
@@ -77,14 +62,13 @@ try:
 except TimeoutException as ex:
     print("Compatibility suite: did not finish with 16 passes. See open browser frame.")
 
-# TODO warn that .NET process was not started.
+# TODO warn that docker process was not started.
 
 print("mode: " + args.mode)
 
 
-if dotnet_process is not None:
-    print("Killing Servirtium.NET")
-    dotnet_process.communicate(input="x".encode("utf-8"))
+print("Killing Servirtium.NET")
+subprocess.Popen(["docker", "stop", "servirtium-compatibility-test"])
 
 print("Closing Selenium")
 chrome.quit()

--- a/compatibility-suite-docker.py
+++ b/compatibility-suite-docker.py
@@ -13,7 +13,7 @@ import argparse
 
 parser = argparse.ArgumentParser(description='Run Servirtium.NET.')
 parser.add_argument("mode", help="Servirtium's mode of operation, i.e. recording a new script or playing an existing one back", choices = ["record", "playback", "direct"])
-parser.add_argument("-p", "--port", help="The port Servirtium will run on", type=int, default=1234)
+parser.add_argument("-p", "--port", help="The port Servirtium will run on", type=int, default=61417)
 parser.add_argument("-d", "--chromedriver", help="The location of the Selenium Chrome Webdriver executable - omit to use one that's on the system PATH")
 parser.add_argument("-t", "--testpage", help="The page to point chrome at to run the tests, use the '%%s' token where the port should be specified. To point back at the original todobackend, specify http://www.todobackend.com/specs/index.html?http://localhost:%%s/todos", default="https://servirtium.github.io/compatibility-suite/index.html?http://localhost:%s/todos")
 parser.add_argument("--backend", help="The real todo backend implementation, only used in 'record' or 'direct' mode", default="http://todo-backend-sinatra.herokuapp.com")
@@ -24,8 +24,9 @@ args = parser.parse_args()
 browser_url = args.testpage %(args.port)
 
 subprocess.call(["docker", "volume", "create", "scripts"])
+subprocess.call(["docker", "rm", "servirtium-compatibility-test", "-f"])
 
-docker_args = ["docker", "run", "-p", "%s:%s" %(str(args.port), str(args.port)), "--volume", "scripts:/Servirtium/test_recording_output", "--name", "servirtium-compatibility-test", "--rm", "-d"]
+docker_args = ["docker", "run", "-p", "%s:%s" %(str(args.port), str(args.port)), "--volume", "scripts:/Servirtium/test_recording_output", "--name", "servirtium-compatibility-test", "-d"]
 
 if args.mode == "record":
     # TODO check that .NET process is already started.

--- a/compatibility-suite-docker.py
+++ b/compatibility-suite-docker.py
@@ -1,0 +1,91 @@
+import sys
+import os
+import signal
+import platform
+from selenium import webdriver
+from selenium.webdriver.common.by import By
+from selenium.webdriver.support.ui import WebDriverWait
+from selenium.common.exceptions import TimeoutException
+from selenium.webdriver.support import expected_conditions as EC
+import subprocess
+import time
+import argparse
+import os.path
+from os import path
+
+parser = argparse.ArgumentParser(description='Run Servirtium.NET.')
+parser.add_argument("mode", help="Servirtium's mode of operation, i.e. recording a new script or playing an existing one back", choices = ["record", "playback", "direct"])
+parser.add_argument("-p", "--port", help="The port Servirtium will run on", type=int, default=1234)
+parser.add_argument("-d", "--chromedriver", help="The location of the Selenium Chrome Webdriver executable - omit to use one that's on the system PATH")
+parser.add_argument("-t", "--testpage", help="The page to point chrome at to run the tests, use the '%%s' token where the port should be specified. To point back at the original todobackend, specify http://www.todobackend.com/specs/index.html?http://localhost:%%s/todos", default="https://servirtium.github.io/compatibility-suite/#port=%s")
+parser.add_argument("--backend", help="The real todo backend implementation, only used in 'record' or 'direct' mode", default="http://todo-backend-sinatra.herokuapp.com")
+parser.add_argument("--timeoutseconds", help="Number of seconds to wait before giving up on a successful run and ending the test run", type=int, default=20)
+parser.add_argument("--serverversion", help="Version of Standalone.Server to use - this is the version it will pull from Nuget. Setting this will make the script to try to get the Servirtium.StandaloneServer from nuget, rather than building from source.")
+parser.add_argument("--nuget", help="Nuget.exe executable path. Default is to use one on the system PATH", default="nuget")
+
+args = parser.parse_args()
+
+dotnet_platform = "netcoreapp3.1"
+
+dotnet_process = None
+# os.environ["HTTP_PROXY"] = "http://localhost:%s" %(args.port)
+browser_url = args.testpage %(args.port)
+
+if args.mode == "direct":
+    browser_url = "http://www.todobackend.com/specs/index.html?%s" %(args.backend)
+else:
+    servirtium_args = []
+    servirtium_launch_command = []
+
+    if args.mode == "record":
+        servirtium_args = ["record", args.backend, "http://localhost:%s" %(args.port), "--urls=http://*:%s" %(args.port)]
+    elif args.mode == "playback":
+        servirtium_args = ["playback", args.backend, "--urls=http://*:%s" %(args.port)]
+    if args.serverversion:
+        #Install from Nuget
+        subprocess.call([args.nuget, "install", "Servirtium.StandaloneServer", "-OutputDirectory", "executable-packages", "-PreRelease", "-NonInteractive", "-Version", args.serverversion])
+        serverpath = "executable-packages/Servirtium.StandaloneServer.%s/lib/%s/Servirtium.StandaloneServer.exe" %(args.serverversion, dotnet_platform)
+        servirtium_launch_command = [serverpath]
+    else:
+        #Build the Servirtium server first if required
+        subprocess.call(["dotnet", "build", "./Servirtium.StandaloneServer/Servirtium.StandaloneServer.csproj"])
+        servirtium_launch_command = ["dotnet", "run", "--project", "./Servirtium.StandaloneServer/Servirtium.StandaloneServer.csproj", "--no-build", "--"]
+    
+    # TODO check that .NET process is already started.
+    with open('compatibility_suite_servirtium_server.log', "w") as outfile:
+        dotnet_process = subprocess.Popen(servirtium_launch_command + servirtium_args, stdout = outfile, stdin = subprocess.PIPE)
+    print("Servirtium.NET server %s (from %s) started - process id: %s " %(args.mode, str(dotnet_process.pid), "Nuget - version "+args.serverversion if args.serverversion else "source"))
+
+chrome_options = webdriver.ChromeOptions()
+#chrome_options.add_argument("--proxy-server=%s" % "localhost:%s" %(args.port))
+chrome_options.add_argument("--auto-open-devtools-for-tabs")
+
+
+if args.chromedriver:
+    chrome = webdriver.Chrome(executable_path=args.chromedriver, options=chrome_options)
+else:
+    chrome = webdriver.Chrome(options=chrome_options)
+
+
+chrome.get(browser_url)
+try:
+    element = WebDriverWait(chrome, args.timeoutseconds).until(
+        EC.text_to_be_present_in_element((By.CLASS_NAME, "passes"), "16")
+    )
+    print("Compatibility suite: all 16 tests passed")
+
+except TimeoutException as ex:
+    print("Compatibility suite: did not finish with 16 passes. See open browser frame.")
+
+# TODO warn that .NET process was not started.
+
+print("mode: " + args.mode)
+
+
+if dotnet_process is not None:
+    print("Killing Servirtium.NET")
+    dotnet_process.communicate(input="x".encode("utf-8"))
+
+print("Closing Selenium")
+chrome.quit()
+print("All done.")

--- a/compatibility-suite-docker.py
+++ b/compatibility-suite-docker.py
@@ -15,9 +15,9 @@ parser = argparse.ArgumentParser(description='Run Servirtium.NET.')
 parser.add_argument("mode", help="Servirtium's mode of operation, i.e. recording a new script or playing an existing one back", choices = ["record", "playback", "direct"])
 parser.add_argument("-p", "--port", help="The port Servirtium will run on", type=int, default=1234)
 parser.add_argument("-d", "--chromedriver", help="The location of the Selenium Chrome Webdriver executable - omit to use one that's on the system PATH")
-parser.add_argument("-t", "--testpage", help="The page to point chrome at to run the tests, use the '%%s' token where the port should be specified. To point back at the original todobackend, specify http://www.todobackend.com/specs/index.html?http://localhost:%%s/todos", default="https://servirtium.github.io/compatibility-suite/#port=%s")
+parser.add_argument("-t", "--testpage", help="The page to point chrome at to run the tests, use the '%%s' token where the port should be specified. To point back at the original todobackend, specify http://www.todobackend.com/specs/index.html?http://localhost:%%s/todos", default="https://servirtium.github.io/compatibility-suite/index.html?http://localhost:%s/todos")
 parser.add_argument("--backend", help="The real todo backend implementation, only used in 'record' or 'direct' mode", default="http://todo-backend-sinatra.herokuapp.com")
-parser.add_argument("--timeoutseconds", help="Number of seconds to wait before giving up on a successful run and ending the test run", type=int, default=20)
+parser.add_argument("--timeoutseconds", help="Number of seconds to wait before giving up on a successful run and ending the test run", type=int, default=30)
 
 args = parser.parse_args()
 

--- a/compatibility-suite.py
+++ b/compatibility-suite.py
@@ -30,11 +30,11 @@ browser_url = args.testpage %(args.port)
 
 if args.mode == "record":
     # TODO check that .NET process is already started.
-    with open('myfile', "w") as outfile:
+    with open('compatibility_suite_servirtium_server.record.log', "w") as outfile:
         dotnet_process = subprocess.Popen(["dotnet", "run", "--project", "./Servirtium.StandaloneServer/Servirtium.StandaloneServer.csproj", "--no-build", "--", "record", args.backend, "http://localhost:%s" %(args.port), "--urls=http://*:%s" %(args.port)], stdout = outfile, stdin = subprocess.PIPE)
     print(".NET record process: "+str(dotnet_process.pid))
 elif args.mode == "playback":
-    with open('myfile', "w") as outfile:
+    with open('compatibility_suite_servirtium_server.playback.log', "w") as outfile:
         dotnet_process = subprocess.Popen(["dotnet", "run", "--project", "./Servirtium.StandaloneServer/Servirtium.StandaloneServer.csproj", "--no-build", "--", "playback", args.backend, "--urls=http://*:%s" %(args.port)], stdout = outfile, stdin = subprocess.PIPE)
     print(".NET playback process: "+str(dotnet_process.pid))
 elif args.mode == "direct":

--- a/compatibility-suite.py
+++ b/compatibility-suite.py
@@ -31,11 +31,11 @@ browser_url = args.testpage %(args.port)
 if args.mode == "record":
     # TODO check that .NET process is already started.
     with open('compatibility_suite_servirtium_server.record.log', "w") as outfile:
-        dotnet_process = subprocess.Popen(["dotnet", "run", "--project", "./Servirtium.StandaloneServer/Servirtium.StandaloneServer.csproj", "--no-build", "--", "record", args.backend, "http://localhost:%s" %(args.port), "--urls=http://*:%s" %(args.port)], stdout = outfile, stdin = subprocess.PIPE)
+        dotnet_process = subprocess.Popen(["dotnet", "run", "--project", "./Servirtium.StandaloneServer/Servirtium.StandaloneServer.csproj", "--no-build", "--", "record", args.backend, str(args.port)], stdout = outfile, stdin = subprocess.PIPE)
     print(".NET record process: "+str(dotnet_process.pid))
 elif args.mode == "playback":
     with open('compatibility_suite_servirtium_server.playback.log', "w") as outfile:
-        dotnet_process = subprocess.Popen(["dotnet", "run", "--project", "./Servirtium.StandaloneServer/Servirtium.StandaloneServer.csproj", "--no-build", "--", "playback", args.backend, "--urls=http://*:%s" %(args.port)], stdout = outfile, stdin = subprocess.PIPE)
+        dotnet_process = subprocess.Popen(["dotnet", "run", "--project", "./Servirtium.StandaloneServer/Servirtium.StandaloneServer.csproj", "--no-build", "--", "playback", args.backend, str(args.port)], stdout = outfile, stdin = subprocess.PIPE)
     print(".NET playback process: "+str(dotnet_process.pid))
 elif args.mode == "direct":
     print("showing reference Sinatra app online without Servirtium in the middle")
@@ -72,7 +72,7 @@ print("mode: " + args.mode)
 
 if dotnet_process is not None:
     print("Killing Servirtium.NET")
-    dotnet_process.communicate(input="x".encode("utf-8"))
+    dotnet_process.communicate(input="\nexit\n".encode("utf-8"))
 
 print("Closing Selenium")
 chrome.quit()

--- a/compatibility-suite.py
+++ b/compatibility-suite.py
@@ -15,7 +15,7 @@ parser = argparse.ArgumentParser(description='Run Servirtium.NET.')
 parser.add_argument("mode", help="Servirtium's mode of operation, i.e. recording a new script or playing an existing one back", choices = ["record", "playback", "direct"])
 parser.add_argument("-p", "--port", help="The port Servirtium will run on", type=int, default=1234)
 parser.add_argument("-d", "--chromedriver", help="The location of the Selenium Chrome Webdriver executable - omit to use one that's on the system PATH")
-parser.add_argument("-t", "--testpage", help="The page to point chrome at to run the tests, use the '%%s' token where the port should be specified. To point back at the original todobackend, specify http://www.todobackend.com/specs/index.html?http://localhost:%%s/todos", default="https://servirtium.github.io/compatibility-suite/#port=%s")
+parser.add_argument("-t", "--testpage", help="The page to point chrome at to run the tests, use the '%%s' token where the port should be specified. To point back at the original todobackend, specify http://www.todobackend.com/specs/index.html?http://localhost:%%s/todos", default="https://servirtium.github.io/compatibility-suite/index.html?http://localhost:%s/todos")
 parser.add_argument("--backend", help="The real todo backend implementation, only used in 'record' or 'direct' mode", default="http://todo-backend-sinatra.herokuapp.com")
 parser.add_argument("--timeoutseconds", help="Number of seconds to wait before giving up on a successful run and ending the test run", type=int, default=20)
 


### PR DESCRIPTION
Docker looks to be the perfect tool for running cross implementation compatibility tests:

Environmental dependencies for each implementation are provided in the container
The test executable for use in the tests can be published to a centrally accessible location (Dockerhub)
Every implementation can easily be tested using a standard script, because it just starts/ stops a container, rather than using implementation specific start / stop logic